### PR TITLE
fix: solve fee options keep loading issue while balance is not enough

### DIFF
--- a/src/popup/pages/transaction.tsx
+++ b/src/popup/pages/transaction.tsx
@@ -62,33 +62,33 @@ const Transaction = ({
     const fee = watch('fee')
 
     const updateFeeOptions = useCallback(async () => {
-        let spendBundle
-        switch (request.data?.method) {
-            case RequestMethodEnum.CREATE_OFFER: {
-                // TODO: disable dynamic fees on CREATE_OFFER
-                // const { offerAssets }: OfferParams = request.data.params
-                // spendBundle = await Offer.generateSecureBundle(
-                //     [],
-                //     offerAssets
-                // )
-                break
-            }
-            case RequestMethodEnum.TRANSFER: {
-                const { to, assetId, amount, memos }: TransferParams =
-                    request.data.params
-                spendBundle = await createTransferSpendBundle({
-                    targetAddress: to,
-                    asset: assetId,
-                    amount,
-                    memos,
-                })
-                break
-            }
-            default:
-                break
-        }
-        if (!spendBundle) return
         try {
+            let spendBundle
+            switch (request.data?.method) {
+                case RequestMethodEnum.CREATE_OFFER: {
+                    // TODO: disable dynamic fees on CREATE_OFFER
+                    // const { offerAssets }: OfferParams = request.data.params
+                    // spendBundle = await Offer.generateSecureBundle(
+                    //     [],
+                    //     offerAssets
+                    // )
+                    break
+                }
+                case RequestMethodEnum.TRANSFER: {
+                    const { to, assetId, amount, memos }: TransferParams =
+                        request.data.params
+                    spendBundle = await createTransferSpendBundle({
+                        targetAddress: to,
+                        asset: assetId,
+                        amount,
+                        memos,
+                    })
+                    break
+                }
+                default:
+                    break
+            }
+            if (!spendBundle) return
             const fees = await getFees(spendBundle)
             return createFeeOptions(
                 fees.map(({ time, fee }) => ({


### PR DESCRIPTION
# Description

fee options will keep loading while the balance of xch is insufficient.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

fee options will display even if the balance of xch is 0 while interacting with namesdao

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules